### PR TITLE
feat: Add X-IM-ORIGIN header and standardize phone numbers

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -73,7 +73,7 @@ for contact in contacts:
 
 ```python
 try:
-    contact = im_sdk.get_contact("1234567890")
+    contact = im_sdk.get_contact("50212345678")
     print(f"Contact Details:")
     print(f"  Name: {contact.full_name}")
     print(f"  Phone: {contact.msisdn}")
@@ -137,7 +137,7 @@ from im_csm_sdk_python.schemas.messages import SendToContactData
 try:
     sent_message = im_sdk.send_to_contact(
         SendToContactData(
-            msisdn="1234567890",
+            msisdn="50212345678",
             message="Hello! This is a test message from the Python SDK.",
             id=str(uuid4())  # Unique message ID
         )
@@ -182,7 +182,7 @@ except Exception as e:
 from uuid import uuid4
 
 # Send messages to multiple contacts
-contacts_to_message = ["1234567890", "0987654321", "1122334455"]
+contacts_to_message = ["50212345678", "50212345678", "50212345678"]
 message_text = "Bulk message from Python SDK"
 
 for msisdn in contacts_to_message:
@@ -262,7 +262,7 @@ def safe_send_message(msisdn: str, message: str):
         return None
 
 # Usage
-result = safe_send_message("1234567890", "Test message")
+result = safe_send_message("50212345678", "Test message")
 if result:
     print(f"Success: {result.message_id}")
 else:

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,12 +74,12 @@ contacts = im_sdk.list_contacts(
 )
 
 # Get a specific contact
-contact = im_sdk.get_contact("1234567890")
+contact = im_sdk.get_contact("50212345678")
 
 # Send a message
 sent_message = im_sdk.send_to_contact(
     SendToContactData(
-        msisdn="1234567890",
+        msisdn="50212345678",
         message="Hello from Python SDK!",
         id="unique-message-id"
     )

--- a/example/main.py
+++ b/example/main.py
@@ -33,7 +33,7 @@ def example_contacts():
         logger.info(f'Contact: {contact.full_name} ({contact.msisdn})')
 
     logger.info('Getting contact...')
-    contact = im_sdk.get_contact('50231241024')
+    contact = im_sdk.get_contact('50212345678')
     logger.info(f'Contact: {contact.full_name} ({contact.msisdn})')
 
 
@@ -50,7 +50,7 @@ def example_messages():
             end_date=end_date,
             start=0,
             limit=50,
-            msisdn='50231241024',
+            msisdn='50212345678',
             direction=MessageDirection.MT,
             delivery_status_enable=True,
         )
@@ -63,7 +63,7 @@ def example_messages():
     logger.info('Sending message to contact...')
     sent_message = im_sdk.send_to_contact(
         SendToContactData(
-            msisdn='50211241024',
+            msisdn='50212345678',
             message='Hello from Python SDK!',
             id=str(uuid4()),
         )

--- a/im_csm_sdk_python/helpers/api_request.py
+++ b/im_csm_sdk_python/helpers/api_request.py
@@ -39,6 +39,15 @@ def send_request(api_request: ApiRequest) -> Response:
         logger.trace(f'Data: {api_request.data}')
         logger.trace(f'Params: {api_request.params}')
 
+        headers = {
+            'Date': auth['Date'],
+            'Authorization': auth['Authorization'],
+            'X-IM-ORIGIN': auth['X-IM-ORIGIN'],
+        }
+        
+        # Log headers for debugging
+        logger.info(f'Request headers: {headers}')
+        
         response = request(
             method=api_request.type,
             url=urljoin(
@@ -46,10 +55,7 @@ def send_request(api_request: ApiRequest) -> Response:
             ),
             json=api_request.data,
             params=api_request.params,
-            headers={
-                'Date': auth['Date'],
-                'Authorization': auth['Authorization'],
-            },
+            headers=headers,
         )
 
         # Raise for HTTP errors

--- a/im_csm_sdk_python/helpers/authentication.py
+++ b/im_csm_sdk_python/helpers/authentication.py
@@ -59,6 +59,7 @@ def authorization(config: dict) -> dict:
 
     auth['Date'] = formatted_date
     auth['Authorization'] = f'IM {config["apiKey"]}:{signature}'
+    auth['X-IM-ORIGIN'] = 'IM_SDK_PYTHON'
 
     logger.trace(f'Auth headers: {auth}')
 


### PR DESCRIPTION
## Overview
Adds missing `X-IM-ORIGIN` header and standardizes phone numbers across the Python SDK.

## Changes
- ✅ Add `X-IM-ORIGIN: IM_SDK_PYTHON` header
- ✅ Standardize all phone numbers to `50212345678`
- ✅ Update documentation examples
- ✅ Add logging for header verification

## Testing
- Header transmission verified via logs
- API status endpoint working correctly
- All examples using consistent phone numbers

## Impact
Ensures Python SDK is fully aligned with JavaScript, Java, PHP, and .NET SDKs.